### PR TITLE
remove build script. only prepare remains.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
   "author": "Vladislav Belous <elkemper@users.noreply.github.com>",
   "license": "MIT",
   "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "prepare": "yarn build"
+    "prepare": "tsc -p tsconfig.json"
   },
   "dependencies": {
     "@types/node": "^22.5.2",


### PR DESCRIPTION
Because this package could be installed via `npm` command, without `yarn` ever beed installed on system - we'd better remove it.